### PR TITLE
retrive ovf disk interface and import to kvm box

### DIFF
--- a/lib/vagrant-mutate/box/virtualbox.rb
+++ b/lib/vagrant-mutate/box/virtualbox.rb
@@ -54,6 +54,28 @@ module VagrantMutate
         end
       end
 
+      def disk_interface
+        disk_contoller = {}
+        disk_type = nil
+        ovf.elements.each("//VirtualHardwareSection/Item") do |device|
+          case device.elements["rasd:ResourceType"].text
+          when "5"
+             # IDE controller
+             disk_contoller[device.elements["rasd:InstanceID"].text] = 'ide'
+           when "6"
+             # SCSI controller
+             disk_contoller[device.elements["rasd:InstanceID"].text] = 'scsi'
+           when "17"
+             # Disk
+             disk_type = device.elements["rasd:Parent"].text
+           when "20"
+             # SATA controller
+             disk_contoller[device.elements["rasd:InstanceID"].text] = 'sata'
+          end
+        end
+        disk_contoller[disk_type] if disk_type
+      end
+
       private
 
       def ovf

--- a/lib/vagrant-mutate/converter/kvm.rb
+++ b/lib/vagrant-mutate/converter/kvm.rb
@@ -16,7 +16,7 @@ module VagrantMutate
 
         uuid = nil
         gui = true
-        disk_bus = 'virtio'
+        disk_bus = @input_box.disk_interface
 
         image_type = @output_box.image_format
         disk = @output_box.image_name

--- a/templates/kvm/box.xml.erb
+++ b/templates/kvm/box.xml.erb
@@ -25,12 +25,16 @@
       <driver name='qemu' type='<%= image_type %>'/>
       <source file='<%= disk %>'/>
       <target dev='vda' bus='<%= disk_bus %>'/>
-    <% if disk_bus == 'virtio' %>
+  <% if disk_bus == 'virtio' %>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
-    <% else %>
-      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
-    <% end %>
     </disk>
+  <% else %>
+      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
+    </disk>
+    <controller type='<%= disk_bus %>' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
+    </controller>
+  <% end %>
     <controller type='usb' index='0'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x2'/>
     </controller>


### PR DESCRIPTION
This patch add function to retrieve disk interface from ovf
and respect it in generating kvm box.

It can be override in vagrant-kvm provider with config.
Some box such as arch linux, depends disk interface because of some boot loader(syslinux) need specific interface that is installed. 

Signed-off-by: Hiroshi Miura miurahr@linux.com
