### PR TITLE
Include CentOS 6.5/RHEL 6.5-friendly Qemu paths.

### DIFF
--- a/lib/vagrant-mutate/converter/kvm.rb
+++ b/lib/vagrant-mutate/converter/kvm.rb
@@ -44,6 +44,7 @@ module VagrantMutate
         qemu_bin_list = [ '/usr/bin/qemu-system-x86_64',
                           '/usr/bin/qemu-system-i386',
                           '/usr/bin/qemu-kvm',
+                          '/usr/libexec/qemu-kvm',
                           '/usr/bin/kvm' ]
         qemu_bin = qemu_bin_list.detect { |binary| File.exists? binary }
         unless qemu_bin


### PR DESCRIPTION
$ rpm -ql qemu-kvm | egrep /qemu-kvm$
   /usr/libexec/qemu-kvm
   /usr/share/qemu-kvm

(The latter is a directory.)
