### PR TITLE
Fix qemu-img version check.

### DIFF
--- a/lib/vagrant-mutate/qemu.rb
+++ b/lib/vagrant-mutate/qemu.rb
@@ -19,7 +19,7 @@ module VagrantMutate
       end
 
       def self.verify_qemu_version(env)
-        usage = `qemu-img`
+        usage = `qemu-img --version`
         if usage =~ /(\d+\.\d+\.\d+)/
           installed_version = Gem::Version.new($1)
           # less than 1.2 or equal to 1.6.x


### PR DESCRIPTION
qemu-img version: `2.1.0`

Version check was failing for qemu-img as executing it without any
arguments returns the following:

```
qemu-img: Not enough arguments
Try 'qemu-img --help' for more information
```

Fixed by using `qemu-img --version`

**Note:** Not certain this also works in previous versions of qemu-img.

Additionally there were 2 test failures but they're unrelated to this change (Tests didn't run at all due to version check failing)

```
TESTS FAILED
These two files do not match <snip>/test/actual_output/virtualbox/boxes/mutate-test/0/kvm/box-disk1.img <snip>/test/expected_output/virtualbox/kvm/box-disk1.img
These two files do not match <snip>/test/actual_output/virtualbox/boxes/mutate-test/0/libvirt/box.img <snip>/test/expected_output/virtualbox/libvirt/box.img
```
