### PR TITLE
Introduce new exception QemuImgNotFound

### DIFF
--- a/lib/vagrant-mutate/errors.rb
+++ b/lib/vagrant-mutate/errors.rb
@@ -22,6 +22,10 @@ module VagrantMutate
       error_key(:qemu_not_found)
     end
 
+    class QemuImgNotFound < VagrantMutateError
+      error_key(:qemu_img_not_found)
+    end
+
     class BoxNotFound < VagrantMutateError
       error_key(:box_not_found)
     end

--- a/lib/vagrant-mutate/qemu.rb
+++ b/lib/vagrant-mutate/qemu.rb
@@ -15,7 +15,7 @@ module VagrantMutate
           end
         end
         # if we make it here qemu-img command was not found
-        raise Errors::QemuNotFound
+        raise Errors::QemuImgNotFound
       end
 
       def self.verify_qemu_version(env)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -8,7 +8,9 @@ en:
       provider_not_supported: |-
         Vagrant-mutate does not support %{provider} for %{direction}
       qemu_not_found: |-
-        Qemu-img was not found in your path
+        QEMU was not found in your path
+      qemu_img_not_found: |-
+        qemu-img was not found in your path
       box_not_found: |-
         The box %{box} was not found
       too_many_boxes_found: |-


### PR DESCRIPTION
At the moment the exception QemuNotFound is used when the binary
qemu-img is not available or if QEMU is not installed. There are
distributions packaging qemu-img in a separate package. So it is
possible to have qemu-img installed without installed QEMU. To
reflect this behavior a new exception QemuImgNotFound exception
should be used when qemu-img was not found.