### PR TITLE
Don't pass unsupported "compat" option to qemu-img < v1.1.0

### DIFF
--- a/lib/vagrant-mutate/converter/converter.rb
+++ b/lib/vagrant-mutate/converter/converter.rb
@@ -93,8 +93,12 @@ module VagrantMutate
         # p for progress bar
         # S for sparse file
         qemu_options = '-p -S 16k'
+        qemu_version = Qemu.qemu_version()
+        if qemu_version >= Gem::Version.new('1.1.0')
+          qemu_options += ' -o compat=1.1'
+        end
 
-        command = "qemu-img convert #{qemu_options} -O #{output_format} -o compat=1.1 #{input_file} #{output_file}"
+        command = "qemu-img convert #{qemu_options} -O #{output_format} #{input_file} #{output_file}"
         @logger.info "Running #{command}"
         unless system(command)
           fail Errors::WriteDiskFailed, error_message: "qemu-img exited with status #{$CHILD_STATUS.exitstatus}"

--- a/lib/vagrant-mutate/qemu.rb
+++ b/lib/vagrant-mutate/qemu.rb
@@ -17,21 +17,25 @@ module VagrantMutate
       fail Errors::QemuImgNotFound
     end
 
-    def self.verify_qemu_version(env)
+    def self.qemu_version()
       usage = `qemu-img --version`
       if usage =~ /(\d+\.\d+\.\d+)/
-        installed_version = Gem::Version.new(Regexp.last_match[1])
-        # less than 1.2 or equal to 1.6.x
-        if installed_version < Gem::Version.new('1.2.0') or (installed_version >= Gem::Version.new('1.6.0') and installed_version < Gem::Version.new('1.7.0'))
-
-          env.ui.warn "You have qemu #{installed_version} installed. "\
-            'This version cannot read some virtualbox boxes. '\
-            'If conversion fails, see below for recommendations. '\
-            'https://github.com/sciurus/vagrant-mutate/wiki/QEMU-Version-Compatibility'
-
-        end
+        return Gem::Version.new(Regexp.last_match[1])
       else
         fail Errors::ParseQemuVersionFailed
+      end
+    end
+
+    def self.verify_qemu_version(env)
+      installed_version = qemu_version()
+      # less than 1.2 or equal to 1.6.x
+      if installed_version < Gem::Version.new('1.2.0') or (installed_version >= Gem::Version.new('1.6.0') and installed_version < Gem::Version.new('1.7.0'))
+
+        env.ui.warn "You have qemu #{installed_version} installed. "\
+          'This version cannot read some virtualbox boxes. '\
+          'If conversion fails, see below for recommendations. '\
+          'https://github.com/sciurus/vagrant-mutate/wiki/QEMU-Version-Compatibility'
+
       end
     end
   end


### PR DESCRIPTION
The option was added by qemu.git commit 6744cba, which wasn't released
until v1.1.0.

RHEL 6.3 still has qemu-img 0.12.1, which works fine when not passed the
unsupported option.