### PR TITLE
Fixed libvirt disk_bus type for Vagrantfile.

### DIFF
--- a/lib/vagrant-mutate/converter/libvirt.rb
+++ b/lib/vagrant-mutate/converter/libvirt.rb
@@ -12,7 +12,7 @@ module VagrantMutate
       def generate_vagrantfile
         <<-EOF
         config.vm.provider :libvirt do |libvirt|
-          libvirt.disk_bus = '#{@input_box.disk_interface}'
+          libvirt.disk_bus = '#{@output_box.disk_interface}'
         end
         EOF
       end


### PR DESCRIPTION

Hi Brian, 

I was really happy to find vagrant-mutate as I am using libvirt/kvm as my default virtualization instead of Virtualbox. My dev system is running Centos 6.7. While the box conversion with vagrant-mutate works fine for the Virtualbox disk images, the generated `Vagrantfile` uses an incompatible disk-controller value for kvm (`libvirt.disk_bus = 'sata'`) on my system:

```
[scheiblc@ibm-t500 scheiblc]$ vagrant box list
opscode-centos-7.1   (virtualbox, 0)
[scheiblc@ibm-t500 scheiblc]$ vagrant mutate opscode-centos-7.1 libvirt
You have qemu 0.12.1 installed. This version cannot read some virtualbox boxes. If conversion fails, see below for recommendations. https://github.com/sciurus/vagrant-mutate/wiki/QEMU-Version-Compatibility
Converting opscode-centos-7.1 from virtualbox to libvirt.
    (100.00/100%)
The box opscode-centos-7.1 (libvirt) is now ready to use.
[scheiblc@ibm-t500 scheiblc]$ cd vagrant_prj/
[scheiblc@ibm-t500 vagrant_prj]$ ls
chefignore  test  Vagrantfile
[scheiblc@ibm-t500 vagrant_prj]$ vagrant up --provider=libvirt
Bringing machine 'default' up with 'libvirt' provider...
==> default: Creating image (snapshot of base box volume).
==> default: Creating domain with the following settings...
==> default:  -- Name:              vagrant_prj_default
==> default:  -- Domain type:       kvm
==> default:  -- Cpus:              1
==> default:  -- Memory:            512M
==> default:  -- Management MAC:    
==> default:  -- Loader:            
==> default:  -- Base box:          opscode-centos-7.1
==> default:  -- Storage pool:      default
==> default:  -- Image:             /var/lib/libvirt/images/vagrant_prj_default.img (40G)
==> default:  -- Volume Cache:      default
==> default:  -- Kernel:            
==> default:  -- Initrd:            
==> default:  -- Graphics Type:     vnc
==> default:  -- Graphics Port:     5900
==> default:  -- Graphics IP:       127.0.0.1
==> default:  -- Graphics Password: Not defined
==> default:  -- Video Type:        cirrus
==> default:  -- Video VRAM:        9216
==> default:  -- Keymap:            en-us
==> default:  -- INPUT:             type=mouse, bus=ps2
==> default:  -- Command line : 
==> default: Creating shared folders metadata...
==> default: Starting domain.
There was an error talking to Libvirt. The error message is shown
below:

Call to virDomainCreateWithFlags failed: unsupported configuration: SATA is not supported with this QEMU binary
[scheiblc@ibm-t500 vagrant_prj]$ 
```

When I change the variable from `#{@input_box.disk_interface}` to `#{@output_box.disk_interface}`, the generated `Vagrantfile` contains the compatible disk_interface value 'virtio' and I can run the converted box on my system.

Can you please have a look at this?

Thanks!

Best regards,

Chris

