### PR TITLE
added --force-virtio switch (refactored)

### DIFF
--- a/lib/vagrant-mutate/converter/converter.rb
+++ b/lib/vagrant-mutate/converter/converter.rb
@@ -4,23 +4,25 @@ require 'shellwords'
 module VagrantMutate
   module Converter
     class Converter
-      def self.create(env, input_box, output_box)
-        case output_box.provider_name
+      #def self.create(env, input_box, output_box)
+      def self.create(env, input_box, output_box, force_virtio='false')
+      case output_box.provider_name
         when 'kvm'
           require_relative 'kvm'
           Kvm.new(env, input_box, output_box)
         when 'libvirt'
           require_relative 'libvirt'
-          Libvirt.new(env, input_box, output_box)
+          Libvirt.new(env, input_box, output_box, force_virtio)
         else
           fail Errors::ProviderNotSupported, provider: output_box.provider_name, direction: 'output'
         end
       end
 
-      def initialize(env, input_box, output_box)
+      def initialize(env, input_box, output_box, force_virtio='false')
         @env = env
         @input_box  = input_box
         @output_box = output_box
+        @force_virtio = force_virtio
         @logger = Log4r::Logger.new('vagrant::mutate')
       end
 

--- a/lib/vagrant-mutate/converter/converter.rb
+++ b/lib/vagrant-mutate/converter/converter.rb
@@ -4,7 +4,6 @@ require 'shellwords'
 module VagrantMutate
   module Converter
     class Converter
-      #def self.create(env, input_box, output_box)
       def self.create(env, input_box, output_box, force_virtio='false')
       case output_box.provider_name
         when 'kvm'

--- a/lib/vagrant-mutate/converter/libvirt.rb
+++ b/lib/vagrant-mutate/converter/libvirt.rb
@@ -1,7 +1,6 @@
 module VagrantMutate
   module Converter
     class Libvirt < Converter
-    attr :force_virtio, false
 
       def generate_metadata
         {

--- a/lib/vagrant-mutate/converter/libvirt.rb
+++ b/lib/vagrant-mutate/converter/libvirt.rb
@@ -13,18 +13,16 @@ module VagrantMutate
       def generate_vagrantfile
 
         if @force_virtio == true
-          <<-EOF
-          config.vm.provider :libvirt do |libvirt|
-            libvirt.disk_bus = '#{@output_box.disk_interface}'
-          end
-          EOF
+          disk_bus = 'virtio'
         else
-          <<-EOF
-          config.vm.provider :libvirt do |libvirt|
-            libvirt.disk_bus = '#{@input_box.disk_interface}'
-          end
-          EOF
+          disk_bus = @input_box.disk_interface
         end
+
+        <<-EOF
+        config.vm.provider :libvirt do |libvirt|
+          libvirt.disk_bus = '#{disk_bus}'
+        end
+        EOF
       end
 
       def write_specific_files

--- a/lib/vagrant-mutate/converter/libvirt.rb
+++ b/lib/vagrant-mutate/converter/libvirt.rb
@@ -1,6 +1,8 @@
 module VagrantMutate
   module Converter
     class Libvirt < Converter
+    attr :force_virtio, false
+
       def generate_metadata
         {
           'provider' => @output_box.provider_name,
@@ -10,11 +12,20 @@ module VagrantMutate
       end
 
       def generate_vagrantfile
-        <<-EOF
-        config.vm.provider :libvirt do |libvirt|
-          libvirt.disk_bus = '#{@input_box.disk_interface}'
+
+        if @force_virtio == true
+          <<-EOF
+          config.vm.provider :libvirt do |libvirt|
+            libvirt.disk_bus = '#{@output_box.disk_interface}'
+          end
+          EOF
+        else
+          <<-EOF
+          config.vm.provider :libvirt do |libvirt|
+            libvirt.disk_bus = '#{@input_box.disk_interface}'
+          end
+          EOF
         end
-        EOF
       end
 
       def write_specific_files

--- a/lib/vagrant-mutate/mutate.rb
+++ b/lib/vagrant-mutate/mutate.rb
@@ -8,6 +8,7 @@ module VagrantMutate
       options = {}
       options[:input_provider] = nil
       options[:version] = nil
+      options[:force_virtio] = false
 
       opts = OptionParser.new do |o|
         o.banner = 'Usage: vagrant mutate <box-name-or-file-or-url> <provider>'
@@ -29,7 +30,7 @@ module VagrantMutate
       argv = parse_options(opts)
       return unless argv
 
-      unless argv.length >= 2
+      unless argv.length == 2
         @env.ui.info(opts.help)
         return
       end
@@ -46,12 +47,7 @@ module VagrantMutate
       output_loader = BoxLoader.new(@env)
       output_box = output_loader.prepare_for_output(input_box.name, options[:output_provider], input_box.version)
 
-      if options[:force_virtio] == true 
-        converter  = Converter::Converter.create(@env, input_box, output_box, options[:force_virtio])
-      else
-        converter  = Converter::Converter.create(@env, input_box, output_box)
-      end
-
+      converter  = Converter::Converter.create(@env, input_box, output_box, options[:force_virtio])
       converter.convert
 
       input_loader.cleanup

--- a/lib/vagrant-mutate/mutate.rb
+++ b/lib/vagrant-mutate/mutate.rb
@@ -19,12 +19,17 @@ module VagrantMutate
              'Specify version for input box') do |p|
           options[:version] = p
         end
+        # check for optional argument to force virtio disk driver in Vagrantfile (for libvirt)
+        o.on('--force-virtio',
+             'Force virtio disk driver in Vagrantfile for libvirt output provider') do |p|
+          options[:force_virtio] = true
+        end
       end
 
       argv = parse_options(opts)
       return unless argv
 
-      unless argv.length == 2
+      unless argv.length >= 2
         @env.ui.info(opts.help)
         return
       end
@@ -41,7 +46,12 @@ module VagrantMutate
       output_loader = BoxLoader.new(@env)
       output_box = output_loader.prepare_for_output(input_box.name, options[:output_provider], input_box.version)
 
-      converter  = Converter::Converter.create(@env, input_box, output_box)
+      if options[:force_virtio] == true 
+        converter  = Converter::Converter.create(@env, input_box, output_box, options[:force_virtio])
+      else
+        converter  = Converter::Converter.create(@env, input_box, output_box)
+      end
+
       converter.convert
 
       input_loader.cleanup

--- a/test/test_force-virtio.rb
+++ b/test/test_force-virtio.rb
@@ -1,0 +1,101 @@
+#!/usr/bin/env ruby
+
+require 'fileutils'
+
+def cleanup
+  puts "\nCLEANING UP"
+  base_output_dir = File.expand_path('../actual_output', __FILE__)
+  if File.directory? base_output_dir
+    FileUtils.rm_rf base_output_dir
+  end
+end
+
+def ensure_pkg_dir
+  pkg_dir = File.expand_path('../../pkg', __FILE__)
+  unless Dir.exist? pkg_dir
+    Dir.mkdir pkg_dir
+  end
+end
+
+def build_plugin
+  puts "\nBUILDING PLUGIN"
+  pkg_dir = File.expand_path('../../pkg', __FILE__)
+  working_dir = Dir.pwd
+  Dir.chdir pkg_dir
+  FileUtils.rm(Dir.glob('*.gem'))
+  system('rake build')
+  Dir.chdir working_dir
+end
+
+def install_plugin
+  puts "\nINSTALLING PLUGIN"
+  pkg_dir = File.expand_path('../../pkg', __FILE__)
+  working_dir = Dir.pwd
+  Dir.chdir pkg_dir
+  system('vagrant plugin install *.gem')
+  Dir.chdir working_dir
+end
+
+# convering libvirt to kvm has some random output which we must replace
+# with the static "random" value in the sample output we are comparing against
+def derandomize_output(input, output_dir)
+  if input == 'libvirt'
+    if File.split(output_dir).last == 'kvm'
+      ['box.xml', 'Vagrantfile'].each do |f|
+        path = File.join(output_dir, f)
+        contents = File.read(path)
+        contents.gsub!(/52:54:00:[0-9a-f:]+/, '52:54:00:cb:b2:80')
+        contents.gsub!(/525400[0-9a-f]+/, '525400cbb280')
+        File.open(path, 'w') do |o|
+          o.write(contents)
+        end
+      end
+    end
+  end
+end
+
+def test(input, outputs)
+  failures = []
+  test_dir = File.expand_path(File.dirname(__FILE__))
+
+  input_box = File.join(test_dir, 'input', input, 'mutate-test.box')
+
+  vagrant_dir = File.join(test_dir, 'actual_output', input)
+  FileUtils.mkdir_p vagrant_dir
+  ENV['VAGRANT_HOME'] = vagrant_dir
+  install_plugin
+
+  outputs.each do |output|
+    puts "\nTESTING #{input} to #{output}"
+    system("vagrant mutate #{input_box} #{output} --force-virtio")
+    # 0 because input boxes are unversioned
+    output_dir = File.join(vagrant_dir, 'boxes', 'mutate-test', '0', output)
+    expected_output_dir = File.join(test_dir, 'expected_output', input, output)
+    derandomize_output(input, output_dir)
+    Dir.foreach(expected_output_dir) do |f|
+      next if f == '.' or f == '..'
+      output = File.join(output_dir, f)
+      expected_output = File.join(expected_output_dir, f)
+      test_passed = FileUtils.compare_file(output, expected_output)
+      unless test_passed
+        failures.push "These two files do not match #{output} #{expected_output}"
+      end
+    end
+  end
+
+  failures
+end
+
+cleanup
+ensure_pkg_dir
+build_plugin
+failures = test('virtualbox', %w(kvm libvirt))
+failures += test('libvirt', ['kvm'])
+failures += test('kvm', ['libvirt'])
+
+if failures.empty?
+  puts "\nALL TESTS PASSED"
+else
+  puts "\nTESTS FAILED"
+  failures.each { |f| puts f }
+end


### PR DESCRIPTION

Hi Brian,

Sorry for the misunderstanding! I was done with the code revision yesterday and only deleted the old branch because I created a new one. Only didn't get to submit the new pull request as it was quite late already when I was done.

Thanks for your feedback, I've rewritten the parameter based on your feedback and indeed could confine the changes to the three files. 

For the vagrant-kvm support, I think it's better to drop it. As you said, the project is abandoned. Also, I remember trying out vagrant-kvm for libvirt/kvm on CentOS before vagrant-libvirt and didn't get it to work at all. 

A Vagrant provider that I want to work with soon too is vagrant-xenserver as I work on projects with Xen hypervisor a lot at my current job. Looking at the plugin, it doesn't look too complex to include support in vagrant-mutate, it's a very basic Vagantfile and a qemu-img call to convert a vmdk to a vhd disk image. Do you think this is good to support in vagrant-mutate? From what I've seen, Xenserver is still in use in a lot of places. 

I've also found https://github.com/sciurus/vagrant-mutate/issues/78 in the open issues and can try to implement that next.

Anyways, really sorry for the confusion. Vagrant-mutate is the first project on github that I want to contribute to and your comments were very helpful for me to improve on my previous attempt.

Thanks!

Chris
