### PR TITLE
Convert VirtualBox parser to using nokogiri

### DIFF
--- a/lib/vagrant-mutate/box/kvm.rb
+++ b/lib/vagrant-mutate/box/kvm.rb
@@ -1,5 +1,5 @@
 require_relative 'box'
-require 'rexml/document'
+require 'nokogiri'
 
 module VagrantMutate
   module Box
@@ -20,8 +20,8 @@ module VagrantMutate
       def disk_interface
         domain_file = File.join(@dir, 'box.xml')
         begin
-          domain = REXML::Document.new(File.read(domain_file))
-          domain.elements['/domain/devices/disk/target'].attributes['bus']
+          domain = File.open(domain_file) { |f| Nokogiri::XML(f) }
+          domain.xpath("//*[local-name()='domain']/*[local-name()='devices']/*[local-name()='disk']/*[local-name()='target']").attribute('bus')
         rescue => e
           raise Errors::BoxAttributeError, error_message: e.message
         end

--- a/lib/vagrant-mutate/box/virtualbox.rb
+++ b/lib/vagrant-mutate/box/virtualbox.rb
@@ -1,4 +1,4 @@
-require 'rexml/document'
+require 'nokogiri'
 require_relative 'box'
 
 module VagrantMutate
@@ -14,7 +14,7 @@ module VagrantMutate
 
       # this is usually box-disk1.vmdk but some tools like packer customize it
       def image_name
-        ovf.elements['//References/File'].attributes['ovf:href']
+        ovf.xpath("//*[local-name()='References']/*[local-name()='File']")[0].attribute("href").value
       end
 
       # the architecture is not defined in the ovf file,
@@ -31,9 +31,9 @@ module VagrantMutate
       def mac_address
         mac = nil
 
-        ovf.elements.each('//vbox:Machine/Hardware//Adapter') do |ele|
-          if ele.attributes['enabled'] == 'true'
-            mac = ele.attributes['MACAddress']
+        ovf.xpath("//*[local-name()='Machine']/*[local-name()='Hardware']/*[local-name()='Network']/*[local-name()='Adapter']").each do |net|
+        if net.attribute("enabled").value == "true"
+            mac = net.attribute("MACAddress").value
             break
           end
         end
@@ -48,9 +48,9 @@ module VagrantMutate
       def cpus
         cpu_count = nil
 
-        ovf.elements.each('//VirtualHardwareSection/Item') do |device|
-          if device.elements['rasd:ResourceType'].text == '3'
-            cpu_count = device.elements['rasd:VirtualQuantity'].text
+        ovf.xpath("//*[local-name()='VirtualHardwareSection']/*[local-name()='Item']/*[local-name()='ResourceType']").each do |item|
+          if item.text == "3"
+            cpu_count = item.parent.xpath("*[local-name()='VirtualQuantity']").text
           end
         end
 
@@ -64,10 +64,10 @@ module VagrantMutate
       def memory
         memory_in_bytes = nil
 
-        ovf.elements.each('//VirtualHardwareSection/Item') do |device|
-          if device.elements['rasd:ResourceType'].text == '4'
-            memory_in_bytes = size_in_bytes(device.elements['rasd:VirtualQuantity'].text,
-                                            device.elements['rasd:AllocationUnits'].text)
+        ovf.xpath("//*[local-name()='VirtualHardwareSection']/*[local-name()='Item']/*[local-name()='ResourceType']").each do |item|
+          if item.text == "4"
+            memory_in_bytes = size_in_bytes(item.parent.xpath("*[local-name()='VirtualQuantity']").text,
+                                            item.parent.xpath("*[local-name()='AllocationUnits']").text)
           end
         end
 
@@ -81,18 +81,18 @@ module VagrantMutate
       def disk_interface
         controller_type = {}
         controller_used_by_disk = nil
-        ovf.elements.each('//VirtualHardwareSection/Item') do |device|
+        ovf.xpath("//*[local-name()='VirtualHardwareSection']/*[local-name()='Item']/*[local-name()='ResourceType']").each do |device|
           # when we find a controller, store its ID and type
           # when we find a disk, store the ID of the controller it is connected to
-          case device.elements['rasd:ResourceType'].text
+          case device.text
           when '5'
-            controller_type[device.elements['rasd:InstanceID'].text] = 'ide'
-           when '6'
-             controller_type[device.elements['rasd:InstanceID'].text] = 'scsi'
-           when '20'
-             controller_type[device.elements['rasd:InstanceID'].text] = 'sata'
-           when '17'
-             controller_used_by_disk = device.elements['rasd:Parent'].text
+            controller_type[device.parent.xpath("*[local-name()='InstanceID']").text] = 'ide'
+          when '6'
+            controller_type[device.parent.xpath("*[local-name()='InstanceID']").text] = 'scsi'
+          when '20'
+            controller_type[device.parent.xpath("*[local-name()='InstanceID']").text] = 'sata'
+          when '17'
+            controller_used_by_disk = device.parent.xpath("*[local-name()='Parent']").text
           end
         end
         if controller_used_by_disk and controller_type[controller_used_by_disk]
@@ -111,7 +111,7 @@ module VagrantMutate
 
         ovf_file = File.join(@dir, 'box.ovf')
         begin
-          @ovf = REXML::Document.new(File.read(ovf_file))
+          @ovf = File.open(ovf_file) { |f| Nokogiri::XML(f) }
         rescue => e
           raise Errors::BoxAttributeError, error_message: e.message
         end

--- a/vagrant-mutate.gemspec
+++ b/vagrant-mutate.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_runtime_dependency "nokogiri"
 end


### PR DESCRIPTION
Convert VirtualBox parser to using nokogiri instead of rexml. This allows us to
use namespace agnostic xpaths, so that we successfully parse some ovf files
which use namespaces in unexpected ways. Fixes #88 

Shouldn't cause any additional burden since Vagrant requires nokogiri anyway.
Also add nokogiri to gemspec for correctness. Perhaps other parsers should be
converted as well.

