### PR TITLE
Updated dependency name for Ruby libvirt bindings in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ First, you must install [qemu-img](http://wiki.qemu.org/Main_Page) and the libvi
 
 #### Red Hat and derivatives
 
-    yum install qemu-img libvirt-devel ruby-libvirt ruby-devel
+    yum install qemu-img libvirt-devel rubygem-ruby-libvirt ruby-devel
 
 #### OS X
 


### PR DESCRIPTION
On both a  RHEL7.3 system and a Fedora23 system that I have access to,
there was no package `ruby-libvirt` found in `yum`/`dnf`. However, a
package of the libvirt bindings for Ruby was found with the `rubygem`
prefix.

Signed-off-by: Steve Kuznetsov skuznets@redhat.com
