### PR TITLE
Updated Red Hat Linux install directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ First, you must install [qemu-img](http://wiki.qemu.org/Main_Page) and the libvi
 
 #### Red Hat and derivatives
 
-    yum install qemu-img libvirt-devel rubygem-ruby-libvirt ruby-devel
+    yum install qemu-img libvirt-devel rubygem-ruby-libvirt ruby-devel redhat-rpm-config
 
 #### OS X
 


### PR DESCRIPTION
In order to successfully install this plugin on a Red Hat Linux
distribution, one must install the `redhat-rpm-config` package in
order to be able to successfully install the FFI gem, which is a
requirement for the plugin.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>