### PR TITLE
Add to support another format of memory size

### DIFF
--- a/lib/vagrant-mutate/box/virtualbox.rb
+++ b/lib/vagrant-mutate/box/virtualbox.rb
@@ -123,7 +123,7 @@ module VagrantMutate
       # defaults to false because ovf MB != megabytes
       def size_in_bytes(qty, unit, mib = false)
         qty = qty.to_i
-        unit = unit.downcase
+        unit = unit.downcase.gsub(/\s+/, '')
         unless mib
           case unit
           when 'kb', 'kilobytes'
@@ -139,15 +139,15 @@ module VagrantMutate
           qty
         when 'kb', 'kilobytes'
           (qty * 1000)
-        when 'kib', 'kibibytes'
+        when 'kib', 'kibibytes', 'byte*2^10'
           (qty * 1024)
         when 'mb', 'megabytes'
           (qty * 1_000_000)
-        when 'm', 'mib', 'mebibytes'
+        when 'm', 'mib', 'mebibytes', 'byte*2^20'
           (qty * 1_048_576)
         when 'gb', 'gigabytes'
           (qty * 1_000_000_000)
-        when 'g', 'gib', 'gibibytes'
+        when 'g', 'gib', 'gibibytes', 'byte*2^30'
           (qty * 1_073_741_824)
         else
           fail ArgumentError, "Unknown unit #{unit}"


### PR DESCRIPTION
vagrant-mutate cannot convert some virtualbox images:
```console
% vagrant mutate ubuntu/xenial64 bhyve
Converting ubuntu/xenial64 from virtualbox to bhyve.
    (100.00/100%)
/home/kakkoko/.vagrant.d/gems/2.4.4/gems/vagrant-mutate-1.2.0/lib/vagrant-mutate/box/virtualbox.rb:153:in `size_in_bytes': Unknown unit byte * 2^20 (ArgumentError)
        from /home/kakkoko/.vagrant.d/gems/2.4.4/gems/vagrant-mutate-1.2.0/lib/vagrant-mutate/box/virtualbox.rb:69:in `block in memory'
        from /usr/local/lib/ruby/2.4/rexml/element.rb:927:in `block in each'
        from /usr/local/lib/ruby/2.4/rexml/xpath.rb:68:in `each'
        from /usr/local/lib/ruby/2.4/rexml/xpath.rb:68:in `each'
        from /usr/local/lib/ruby/2.4/rexml/element.rb:927:in `each'
        from /home/kakkoko/.vagrant.d/gems/2.4.4/gems/vagrant-mutate-1.2.0/lib/vagrant-mutate/box/virtualbox.rb:67:in `memory'
        from /home/kakkoko/.vagrant.d/gems/2.4.4/gems/vagrant-mutate-1.2.0/lib/vagrant-mutate/converter/bhyve.rb:24:in `generate_vagrantfile'
        from /home/kakkoko/.vagrant.d/gems/2.4.4/gems/vagrant-mutate-1.2.0/lib/vagrant-mutate/converter/converter.rb:61:in `write_vagrantfile'
        from /home/kakkoko/.vagrant.d/gems/2.4.4/gems/vagrant-mutate-1.2.0/lib/vagrant-mutate/converter/converter.rb:42:in `convert'
        from /home/kakkoko/.vagrant.d/gems/2.4.4/gems/vagrant-mutate-1.2.0/lib/vagrant-mutate/mutate.rb:50:in `execute'
        from /usr/local/lib/ruby/gems/2.4/gems/vagrant-2.0.3/lib/vagrant/cli.rb:46:in `execute'
        from /usr/local/lib/ruby/gems/2.4/gems/vagrant-2.0.3/lib/vagrant/environment.rb:269:in `cli'
        from /usr/local/lib/ruby/gems/2.4/gems/vagrant-2.0.3/bin/vagrant:154:in `<top (required)>'
        from /usr/local/bin/vagrant:23:in `load'
        from /usr/local/bin/vagrant:23:in `<main>'
```

OVF(DMTF DSP0004(*1)) defines flexible format of programatic units.
(for instance, "byte * 2^10" == "kibibytes")
This commit supports three often-used representation:
  * "byte * 2^10" (means "kibibytes")
  * "byte * 2^20" (means "mebibytes")
  * "byte * 2^30" (means "gibibytes")

(*1) http://www.dmtf.org/standards/published_documents/DSP0004_2.7.0.pdf